### PR TITLE
doc: philosophy, design and roadmap.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,46 @@
+# Source-crafter
+
+A platform-agnostic, AI-friendly way to build UIs. Describe the interface in YAML, let the engine render it on the browser, Android, iOS, or terminal — same source, native output on every surface.
+
+## What source-crafter covers
+
+Every UI product is a mix of three concerns. Source-crafter takes the two big ones off your plate and gives you a clean surface for the third.
+
+```mermaid
+flowchart TD
+    UI([UI work in a typical product])
+
+    UI --> R["<b>Component Rendering + Layout</b><br/>50%"]
+    UI --> B["<b>Business Logic</b><br/>25%"]
+    UI --> F["<b>Flow + Transition</b><br/>25%"]
+
+    R --> R1[Modularization]
+    R --> R2[Layout System]
+    R --> R3[Styling & States]
+
+    B --> B1[Data Integration]
+    B --> B2[State & Binding]
+    B --> B3[Handlers & Actions]
+
+    F --> F1[Navigation]
+    F --> F2[Page Flow]
+    F --> F3[Transitions]
+    F --> F4[Animations]
+
+    classDef area fill:#1f3a1f,stroke:#4ade80,color:#e5e7eb,font-weight:bold
+    classDef leaf fill:#3a1f1f,stroke:#f87171,color:#fde68a
+    class R,B,F area
+    class R1,R2,R3,B1,B2,B3,F1,F2,F3,F4 leaf
+```
+
+**Component Rendering + Layout (50%)** and **Flow + Transition (25%)** are what the engine owns. You describe them in YAML — the engine parses, validates, lays out, and drives the platform adapter. **Business Logic (25%)** stays yours: you write providers to fetch data and handlers to run business rules, the engine wires them in by name.
+
+Net effect: the mechanical 75% of a typical UI shrinks to a folder of YAML files, and the 25% that's actually your product stays in code you control.
+
+## Documentation
+
+Three docs, read in this order:
+
+- [**docs/philosophy.md**](./docs/philosophy.md) — why this exists, who it's for, what's in scope and what isn't.
+- [**docs/design.md**](./docs/design.md) — how it works under the hood: YAML → Rust engine → render plan → platform adapter → native UI.
+- [**docs/roadmap.md**](./docs/roadmap.md) — where it's going: POC → MVP → Enhancements → Moderation, with concrete checkpoints.

--- a/docs/design.md
+++ b/docs/design.md
@@ -1,0 +1,50 @@
+# Source-crafter — Design
+
+The way the system works under the hood is fairly simple. The YAML file describing the UI is read by an engine written in Rust. The engine parses it, validates it, and produces a normalized render plan that captures everything needed to draw the UI. A platform-specific adapter then takes the render plan and produces the actual UI on the device. The engine is identical across every platform; only the adapter changes.
+
+```mermaid
+flowchart LR
+    YAML[YAML files] --> Engine
+    Logic[Your handlers<br/>and providers] <--> Engine
+    Engine --> Adapter[Platform adapter]
+    Adapter --> UI[Native UI]
+```
+
+Component rendering happens through a small set of atomic primitives — box, text, image, click-region, edit-field, scroll, group, and form. Everything else is built from these. A button, for example, is just a box with a text inside it wrapped in a click-region. A composite primitive defined in YAML is reduced to atomic primitives before the render plan reaches the adapter. The adapter then turns each atomic primitive into a real platform UI element — a DOM node on the web, a Compose composable on Android, a SwiftUI view on iOS.
+
+Layout is described through properties on the container components themselves. A box with `direction: horizontal` and `gap: 8` lays out its children side by side with 8 units between them. Properties like `span`, `justify`, `columns`, `layer`, `collapseBelow`, and `stackBelow` control proportional sizing, alignment, grid arrangement, z-ordering, and responsive behavior. The engine computes the final size and position of each element and emits this in the render plan. The adapter then applies the computed layout to the native UI tree using CSS flex or grid on the web, Compose `Modifier` on Android, or SwiftUI's layout system on iOS.
+
+Cross-component interactions are wired through the `on:` field and reference syntax. A component can react to user events by declaring something like `on: { click: handlerName }`, and one component can read another's state through references like `$email-input.value` or `$state.searchQuery`. The engine maintains a state store keyed by component id and field name. When the user types in an edit-field, the engine updates the corresponding state slot, finds every prop that subscribes to it through references, and pushes the updated values to the adapter. Built-in actions such as `show`, `hide`, `toggle`, `set`, and `increment` cover most simple cases without requiring user code.
+
+Business logic is integrated through providers and handlers. When a YAML page needs data from the backend, it references a named provider through the `data:` field. The provider itself is user-written code — a function that calls the backend and returns a result — and the engine calls it, holds onto the result, and automatically shows loading or error states. Handlers follow the same pattern: a YAML interaction can call a handler by name, and the handler can read component state, make API calls, and return actions for the engine to execute. The engine owns the wiring; the user owns the business logic.
+
+Application flow is handled through navigation actions. A YAML page can trigger a navigation through the `do: navigate` action, specifying the target page name and any data to pass. The engine maintains an in-memory history stack and supports `do: back` to return to the previous page. Data passed via `with:` in the navigation becomes available in the destination page through the `$nav` reference. URL routing — mapping browser URLs to YAML pages — is layered on top of this in-memory navigation and is being built out.
+
+See [layer.md](./layer.md) for the layers of UI work source-crafter covers.
+
+The YAML files are not compiled into the application binary. Instead, after the developer writes or updates a YAML, a build step produces the YAML files together with a manifest file that maps each page or route to the YAML version that should be rendered for it. Both the built YAML files and the manifest are stored in cloud storage — typically S3 or a CDN, sometimes a database — so applications can fetch them quickly without latency. When an application starts or navigates to a new page, it first fetches the manifest to know which YAML to load, then fetches the actual YAML and renders. When the developer updates a YAML and rebuilds, the manifest is regenerated to point at the new YAML version, and the next application fetch picks up the updated structure automatically.
+
+Live data is handled separately. Anything that comes from the backend through a data provider is always fetched fresh from the provider's source at render time. Provider responses are not stored in the manifest or in the built YAML; they are pulled live every time the page needs them. So the UI structure is cached and served instantly from storage, but the data inside it is never stale.
+
+There is no app store review, no need for users to update their app, and no new binary release for most UI changes. Only changes that require new providers, new handlers, or new atomic primitives need a binary update.
+
+```mermaid
+sequenceDiagram
+    actor Dev as Developer
+    participant Storage as Storage<br/>(S3 / CDN / DB)
+    participant App as User's app
+    participant Backend as Your backend
+
+    Note over App: Engine + adapter + handlers<br/>already installed on the device.
+
+    Dev->>Storage: Publish YAML + new manifest
+    Note over Dev,Storage: No app binary build,<br/>no App Store review.
+
+    App->>Storage: Fetch manifest, then YAML files
+    Storage->>App: Latest version
+    App->>Backend: Fetch live data via providers
+    Backend->>App: Fresh data each time
+    App->>App: Engine renders
+```
+
+The decisions that have already landed are these: the engine-core is in Rust and produces a normalized render plan, the platform adapter calls native UI directly, the YAML is fetched at runtime, and the SDK only ships adapters and handler libraries. What is still ahead is the actual engine implementation, the platform adapters for browser, Android, and iOS, the handler libraries for the host languages, and the validation contract for the YAML schema.

--- a/docs/layer.md
+++ b/docs/layer.md
@@ -1,0 +1,34 @@
+# Layers of UI work
+
+Every UI product is a mix of three concerns. Source-crafter owns two of them (75%) and gives you a clean surface for the third.
+
+```mermaid
+flowchart TD
+    UI([UI work in a typical product])
+
+    UI --> R["<b>Component Rendering + Layout</b><br/>50%"]
+    UI --> B["<b>Business Logic</b><br/>25%"]
+    UI --> F["<b>Flow + Transition</b><br/>25%"]
+
+    R --> R1[Modularization]
+    R --> R2[Layout System]
+    R --> R3[Styling & States]
+
+    B --> B1[Data Integration]
+    B --> B2[State & Binding]
+    B --> B3[Handlers & Actions]
+
+    F --> F1[Navigation]
+    F --> F2[Page Flow]
+    F --> F3[Transitions]
+    F --> F4[Animations]
+
+    classDef area fill:#1f3a1f,stroke:#4ade80,color:#e5e7eb,font-weight:bold
+    classDef leaf fill:#3a1f1f,stroke:#f87171,color:#fde68a
+    class R,B,F area
+    class R1,R2,R3,B1,B2,B3,F1,F2,F3,F4 leaf
+```
+
+- **Component Rendering + Layout (50%)** — engine-owned. Described in YAML; the engine parses, validates, and lays out.
+- **Business Logic (25%)** — user-owned. You write providers (data fetching) and handlers (business rules); the engine wires them in by name.
+- **Flow + Transition (25%)** — engine-owned. Navigation, page transitions, and animations are declared in YAML and driven by the engine.

--- a/docs/philosophy.md
+++ b/docs/philosophy.md
@@ -1,0 +1,17 @@
+# Source-crafter — Philosophy
+
+UI can be broadly divided into two major areas: static content and dynamic content.
+
+Static content generally refers to components, forms, API callers, simple view/state transitions. Effectively, they are repetitive, just that they are driven with schema and network integration.
+
+On the other hand, Dynamic content is composed of elements which change per user, per device and more such params. It can be more creative like a 3D view, fancy and comes with platform specific heavy implementation details.
+
+This project mainly aims to reduce or maximise eradication of redundant effort required to build the static content by implementing a platform agnostic DSL which later can translate to your stack. It doesn't enforce coding patterns, architecture, but gives you full freedom to adapt the output to your stack.
+
+Additionally this enables to move faster cause the code surface exposed to your coding agent is minimal to writing the spec which we propose in YAML. Without that, an AI agent writing UI in a framework has to learn the framework AND your team's conventions before it can produce anything reliable — frameworks let you build the same UI in many different ways, and every codebase ends up with its own setup. With YAML there's nothing to learn — the structure is fixed, AI writes the spec, the engine renders. That's what people are calling vibe coding.
+
+This project mainly targets the middle ground of UI development. Applications like dashboards, admin portals, banking interfaces, and similar business workflows are a good fit, since they generally focus on functionality and flow rather than complex transitions or highly customized interactions. For such applications, consistency and maintainability matter more than unlimited customization, which makes a YAML-driven approach work well.
+
+On the other hand, highly customized UIs such as game-like interfaces, motion-heavy marketing pages, drawing canvases, or real-time collaborative editors can technically be represented in YAML. However, the volume of YAML required for them defeats the readability and AI-friendliness benefits. For such cases, framework code is the more suitable approach.
+
+The goal here is not to replace every UI development approach. The aim is to provide a structured, reusable, and AI-friendly way to build UIs where consistency, maintainability, and faster development are the priority.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -1,0 +1,88 @@
+# Source-crafter — Roadmap
+
+The roadmap is organized as four progressive stages: **POC**, **MVP**, **Enhancements**, **Moderation**. Each stage carries a top-level goal and a list of checkpoints. Checkpoints are stated as **goals achieved**, not tasks to do — they describe the outcome we expect to see, not the work that produces it.
+
+---
+
+## 1. POC — Proof of Concept
+
+**Goal.** Prove that a YAML file can produce a visible, interactive UI on a real platform.
+
+**Checkpoints:**
+
+- [ ] YAML files can be loaded, parsed, and validated without runtime crashes.
+- [ ] The browser adapter renders a YAML page into real DOM elements.
+- [ ] All atomic primitives (box, text, image, click-region, edit-field, scroll, group) are visible on screen.
+- [ ] A composite primitive defined in YAML can be referenced and reused from another YAML file.
+- [ ] A small demo page produces visual output indistinguishable from a hand-written HTML+CSS equivalent.
+- [ ] A first non-trivial example — a page with header, sidebar, content area, and a form — renders correctly.
+
+**Stage exit criterion.** The architecture is no longer hypothetical: a working browser demo exists and can be shown to anyone.
+
+---
+
+## 2. MVP — Minimum Viable Product
+
+**Goal.** A real team can ship a real product using source-crafter on the browser. Production-quality on one platform beats half-quality on five.
+
+**Checkpoints:**
+
+- [ ] All five UI stages work end-to-end: render, layout, cross-component interaction, business logic, navigation.
+- [ ] Forms with field-level validation can be expressed entirely in YAML.
+- [ ] Data providers with loading and error states are fully integrated with the engine.
+- [ ] Multi-page navigation with a working history stack, back behavior, and route-based URL handling is supported.
+- [ ] An application with at least ten pages can be built and runs end-to-end without crashes or layout glitches.
+- [ ] Browser-adapter performance is acceptable for real product use — no perceptible frame drops on typical pages.
+- [ ] The schema (yaml.md) is stable enough that page authors don't get broken by version bumps within the MVP timeframe.
+- [ ] At least one team outside the core maintainers has built something non-trivial with source-crafter and shipped it.
+
+**Stage exit criterion.** Source-crafter is production-quality on the browser and at least one external user has shipped a real product on it.
+
+---
+
+## 3. Enhancements
+
+**Goal.** Expand the surface to cover more platforms, patterns, and product needs — without compromising the schema or the engine's predictability.
+
+**Checkpoints:**
+
+- [ ] Additional platform adapters are available — Android, iOS — each rendering the same YAML correctly.
+- [ ] Library imports (component libraries, theme packs, font sources) are supported and work in real products.
+- [ ] Animations and transitions, including continuous loops, render correctly across platforms.
+- [ ] The medium-priority gaps surfaced in the audit are addressed as concrete user demand arises: internationalization, real-time data, drag and drop, app-level keyboard shortcuts, file uploads, media (video/audio), error boundaries, lazy loading / virtualization, theme switching.
+- [ ] The low-priority gaps (context menus, multi-touch gestures, clipboard actions, free-form canvas, webview/iframe embeds, print layouts) are covered as needed.
+- [ ] A developer-experience layer exists — hot reload of YAML changes during development, a parse-time error overlay, and an in-app inspector for live state and references.
+- [ ] AI-driven YAML generation has at least one working integration where a prompt in plain English produces a renderable page.
+
+**Stage exit criterion.** Source-crafter is the natural choice for multi-platform product UIs within its target zone, and the platform adapter set covers the surfaces most teams ship on.
+
+---
+
+## 4. Moderation — Steady State
+
+**Goal.** Keep the project stable, responsive, and trustworthy for production users. This stage does not end — it is the ongoing posture once the framework is in real use.
+
+**Checkpoints:**
+
+- [ ] Bug reports have a clear intake, triage, and resolution path that users can rely on.
+- [ ] Performance regressions are caught by automated checks before each release lands on users.
+- [ ] Schema changes follow a documented versioning and migration policy — no silent breaking changes.
+- [ ] Backward-compatibility commitments are written down and honored.
+- [ ] A feedback channel between users and maintainers exists and stays responsive.
+- [ ] Documentation (philosophy, design, yaml schema, roadmap) stays in sync with the shipped behavior — no documented field that doesn't work, no working field that isn't documented.
+- [ ] Security issues have a private disclosure path and are handled with clear timelines.
+
+**Stage characteristic.** Every new feature added at any future iteration passes through this same gate — backward compatibility, performance budget, documentation, regression tests — before it's considered done.
+
+---
+
+## How the stages relate
+
+| Stage | What changes | What stays the same |
+|---|---|---|
+| **POC** | architecture validated, first primitives working | nothing yet — everything still being decided |
+| **MVP** | full feature set on one platform (browser); real users | the schema (yaml.md) stabilizes; engine internals can still shift |
+| **Enhancements** | more platforms, more patterns, more libraries | the schema's core stays additive — no breaking changes |
+| **Moderation** | bug fixes, regressions, polish | the surface is now public; everything is contract |
+
+Each stage builds on the previous one. The order is fixed: there's no point in adding Android support before the browser ships a real product, and no point chasing AI generation before the schema is stable. Each stage's exit criterion gates the next.


### PR DESCRIPTION
Three foundational docs to anchor the project before implementation lands.

- philosophy.md — why source-crafter exists. UI divides into static content (repetitive, schema-driven) and dynamic content (creative, platform-specific). This project targets the static middle — dashboards, admin panels, banking flows — where consistency and AI-friendliness matter more than unlimited customization.
- design.md— how it works under the hood. YAML → Rust engine → normalized render plan → platform adapter → native UI. Covers atomic primitives, layout properties, cross-component wiring via references, providers and handlers for business logic, navigation, and the manifest + CDN distribution model that lets UI updates ship without app-store review. 
 - roadmap.md — where it's going. Four stages (POC → MVP → Enhancements → Moderation) with checkbox checkpoints stated as goals achieved rather than tasks to do. Fixed order — no Android before browser ships a real product, no AI generation before the schema stabilizes.